### PR TITLE
Fix: Default content for events/sponsors and console errors

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
-import { fetchContent } from '../utils/api'; // Import fetchContent
-// Recharts imports are no longer needed
-import { Users, Users2, BarChart3, Clock, Award, HelpCircle } from 'lucide-react'; // Removed TrendingUp, PieChart as PieIcon
+import { fetchContent } from '../utils/api';
+import { 
+    Users, Users2, BarChart3, Clock, Award, HelpCircle, 
+    CalendarDays, CalendarClock, UsersRound, Briefcase // Added new icons
+} from 'lucide-react';
 
 // Interface for data from stats.json
 interface JsonStatItem {
@@ -39,23 +41,43 @@ const Stats: React.FC = () => {
 
   // Helper function to map icon string to ReactNode
   const mapIconStringToNode = (iconString?: string): React.ReactNode => {
-    const iconProps = { className: "w-10 h-10" };
+    const iconProps = { className: "w-10 h-10" }; // Default props for icons
     switch (iconString?.toLowerCase()) {
+      // Mappings for original initialStatsData (if still relevant or as fallback)
       case 'award':
-      case 'events': // Added alias based on initialStatsData id
         return <Award {...iconProps} />;
-      case 'users':
-      case 'participants': // Added alias
-        return <Users {...iconProps} />;
-      case 'users2':
-      case 'speakers': // Added alias
+      // case 'users': // 'users' from initialStatsData might conflict with 'people' from JSON if not handled carefully
+      //   return <Users {...iconProps} />; 
+      case 'users2': // For "سخنران متخصص" if using initial data
         return <Users2 {...iconProps} />;
       case 'clock':
-      case 'hours': // Added alias
         return <Clock {...iconProps} />;
+      
+      // Mappings for stats.json values
+      case 'event': // From stats.json "icon": "event"
+        return <CalendarDays {...iconProps} />;
+      case 'calendar_today': // From stats.json "icon": "calendar_today"
+        return <CalendarClock {...iconProps} />;
+      case 'people': // From stats.json "icon": "people"
+        return <Users {...iconProps} />; // Re-using Users icon
+      case 'groups': // From stats.json "icon": "groups"
+        return <UsersRound {...iconProps} />;
+      case 'business': // From stats.json "icon": "business"
+        return <Briefcase {...iconProps} />;
+
+      // Aliases from previous implementation (if any item in JSON might use these)
+      case 'events': 
+        return <Award {...iconProps} />; // Or CalendarDays if more appropriate
+      case 'participants': 
+        return <Users {...iconProps} />; // Or UsersRound
+      case 'speakers': 
+        return <Users2 {...iconProps} />;
+      case 'hours': 
+        return <Clock {...iconProps} />;
+        
       default:
-        console.warn(`Unknown icon string: ${iconString}, using default.`);
-        return <HelpCircle {...iconProps} />; // Default icon
+        console.warn(`Unknown icon string: ${iconString}, using default HelpCircle.`);
+        return <HelpCircle {...iconProps} />; // Default fallback icon
     }
   };
 


### PR DESCRIPTION
This commit addresses your feedback regarding default content in the Upcoming Events and Sponsors sections, and resolves several console errors.

Upcoming Events:
- I modified `UpcomingEvent.tsx` to always display 3 events. If `upcoming-event.json` provides fewer than 3 active events, I supplement the list with active events from `DEFAULT_EVENTS` to reach a total of 3.
- I adjusted the console warning for "No active upcoming events found" to be more accurate given the new supplementation logic.

Sponsors Section:
- I updated `Sponsors.tsx` to use `DEMO_SPONSORS` to fill the 3x6 grid (up to 18 sponsors) if `sponsors.json` is empty or provides an insufficient number of logos.
- I ensured robust processing of sponsor data by providing default values for all fields in a SponsorEntry, preventing potential errors if data is incomplete.

Statistics/Achievements Section:
- I fixed icon display in `Stats.tsx` by correctly mapping icon strings from `stats.json` (e.g., "event", "people") to varied Lucide icon components. This resolves the issue of icons appearing the same and associated "Unknown icon string" console errors.

Console Errors:
- I addressed the "No active upcoming events found in upcoming-event.json" warning to be more informative.
- I eliminated "Unknown icon string" errors for the Statistics section by improving icon mapping.

These changes enhance the user experience by ensuring key sections are always populated with content and by cleaning up console noise.